### PR TITLE
Feature/mark orders as delivered

### DIFF
--- a/app/controllers/adminUsers/employees/orders_controller.rb
+++ b/app/controllers/adminUsers/employees/orders_controller.rb
@@ -2,11 +2,27 @@ module AdminUsers
   module Employees
     class OrdersController < AdminUsers::ApplicationController
       def index
-        render :index, locals: { orders: Order.where(employee: employee), employee: employee }
+        render :index, locals: { orders: Order.where(employee: employee).order(:status),
+                                 employee: employee }
+      end
+
+      def update
+        if order.not_delivered?
+          order.delivered!
+          redirect_back fallback_location: admin_users_employee_orders_path,
+                        notice: 'Order has been delivered!'
+        else
+          redirect_back fallback_location: admin_users_employee_orders_path,
+                        notice: 'Order has been already delivered!'
+        end
       end
 
       def employee
         @employee ||= Employee.find(params[:employee_id])
+      end
+
+      def order
+        @order ||= Order.find(params[:id])
       end
     end
   end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -12,4 +12,8 @@ class Employee < ApplicationRecord
   def earned_points
     received_kudos.count - orders.sum(&:purchase_price).to_i
   end
+
+  def pending_orders
+    orders.not_delivered.count
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,5 @@
 class Order < ApplicationRecord
+  enum status: { not_delivered: 0, delivered: 1 }
   serialize :reward_snapshot
 
   belongs_to :reward

--- a/app/views/admin_users/employees/index.html.erb
+++ b/app/views/admin_users/employees/index.html.erb
@@ -8,7 +8,12 @@
       <div class="card-body">
         <p class="card-text"><span class="font-weight-bold">Email: </span><%= employee.email %></p>
         <p class="card-text"><span class="font-weight-bold">Number of kudos: </span><%= employee.number_of_available_kudos %></p>
-        <div><%= link_to 'Employee\'s orders', admin_users_employee_orders_path(employee), class: 'btn btn-outline-success' %></div>
+        <div>
+          <%= link_to admin_users_employee_orders_path(employee), class: 'btn btn-outline-success' do %>
+            <span>Employee's orders</span>
+            <span>(<%= employee.pending_orders %>)<span>
+          <% end %>
+        </div>
         <div class="btn-group mt-3" role="group" aria-label="Basic mixed styles example">
           <span class="btn btn-warning"><%= link_to 'Edit', edit_admin_users_employee_path(employee), class: 'btn btn-warning' %></span>
           <span class="btn btn-danger"><%= link_to 'Remove', admin_users_employee_path(employee), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %></span>

--- a/app/views/admin_users/employees/orders/index.html.erb
+++ b/app/views/admin_users/employees/orders/index.html.erb
@@ -12,6 +12,12 @@
           <p class="card-text"><span class="font-weight-bold">Reward title: </span><%= order.reward_snapshot.title %></p>
           <p class="card-text"><span class="font-weight-bold">Reward description: </span><%= order.reward_snapshot.description %></p>
           <p class="card-text"><span class="font-weight-bold">Reward price: </span><%= order.purchase_price %></p>
+          <%= button_to admin_users_employee_order_path(employee, order), method: :patch, data: {confirm: 'Are you sure?'}, disabled: order.delivered?, class: 'btn btn-primary mt-2 mb-2' do %>
+            <span class="mx-1">
+              <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill="#fff" d="M2 11.741c-1.221-1.009-2-2.535-2-4.241 0-3.036 2.464-5.5 5.5-5.5 1.706 0 3.232.779 4.241 2h4.259c.552 0 1 .448 1 1v2h4.667c1.117 0 1.6.576 1.936 1.107.594.94 1.536 2.432 2.109 3.378.188.312.288.67.288 1.035v4.48c0 1.156-.616 2-2 2h-1c0 1.656-1.344 3-3 3s-3-1.344-3-3h-4c0 1.656-1.344 3-3 3s-3-1.344-3-3h-2c-.552 0-1-.448-1-1v-6.259zm6 6.059c.662 0 1.2.538 1.2 1.2 0 .662-.538 1.2-1.2 1.2-.662 0-1.2-.538-1.2-1.2 0-.662.538-1.2 1.2-1.2zm10 0c.662 0 1.2.538 1.2 1.2 0 .662-.538 1.2-1.2 1.2-.662 0-1.2-.538-1.2-1.2 0-.662.538-1.2 1.2-1.2zm-7.207-11.8c.135.477.207.98.207 1.5 0 3.036-2.464 5.5-5.5 5.5-.52 0-1.023-.072-1.5-.207v4.207h1.765c.549-.614 1.347-1 2.235-1 .888 0 1.686.386 2.235 1h5.53c.549-.614 1.347-1 2.235-1 .888 0 1.686.386 2.235 1h1.765v-4.575l-1.711-2.929c-.179-.307-.508-.496-.863-.496h-4.426v6h-2v-9h-2.207zm5.207 4v3h5l-1.427-2.496c-.178-.312-.509-.504-.868-.504h-2.705zm-10.5-6c1.932 0 3.5 1.568 3.5 3.5s-1.568 3.5-3.5 3.5-3.5-1.568-3.5-3.5 1.568-3.5 3.5-3.5zm.5 3h2v1h-3v-3h1v2z"/></svg>
+            </span>
+            <span>Deliver</span>
+          <% end %>
         </div>
       </li>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     resources :kudos, only: [:index, :destroy]
     resources :employees, except: [:show] do
       scope module: 'employees' do
-        resources :orders, only: [:index]
+        resources :orders, only: [:index, :update]
       end
     end
     resources :company_values

--- a/db/migrate/20220703204826_add_status_to_orders.rb
+++ b/db/migrate/20220703204826_add_status_to_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :orders, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_27_094608) do
+ActiveRecord::Schema.define(version: 2022_07_03_204826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_094608) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "reward_snapshot"
+    t.integer "status", default: 0, null: false
     t.index ["employee_id"], name: "index_orders_on_employee_id"
     t.index ["reward_id"], name: "index_orders_on_reward_id"
   end

--- a/spec/system/admin/order_delivery_spec.rb
+++ b/spec/system/admin/order_delivery_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Order delivery management', type: :system do
+  let(:admin_user) { create(:admin_user) }
+  let(:employee) { create(:employee) }
+  let!(:order) { create(:order, employee: employee) }
+
+  before do
+    login_admin(admin_user)
+    visit('/admin/employees')
+  end
+
+  it 'can see the number of undelivered orders' do
+    within("li[test_id='employee_#{employee.id}") do
+      expect(page).to have_link("Employee's orders (1)")
+    end
+  end
+
+  it 'can deliver order only once' do
+    click_link("Employee's orders (1)")
+    expect(page).to have_current_path(admin_users_employee_orders_path(employee))
+
+    within("li[test_id='order_#{order.id}") do
+      expect(page).to have_button('Deliver')
+    end
+
+    click_button('Deliver')
+    page.accept_alert
+    expect(page).to have_current_path(admin_users_employee_orders_path(employee))
+    expect(page).to have_text('Order has been delivered')
+
+    order.reload
+    expect(order.status).to eq 'delivered'
+    within("li[test_id='order_#{order.id}") do
+      expect(page).to have_button('Deliver', disabled: true)
+    end
+  end
+end


### PR DESCRIPTION
Sprint 5 task 1

Implemented features according to AC:

- Admin can click on the "deliver" button that is next to the order
- After clicking on the "deliver" button, the admin is asked to confirm their action, as it cannot be undone
- Once an order is delivered, it cannot be delivered again
- Not delivered orders are listed on top of the orders list in the admin panel
- There's a system spec for admin delivering an order
- Admin's link to orders contains the number of not delivered orders, e.g., "orders (3)"

https://user-images.githubusercontent.com/56922072/177385289-1d1130d0-9c84-4ebb-a9f1-86cf3708559d.mov


