### PR TITLE
Feature/filtering orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,8 @@
 class OrdersController < ApplicationController
   before_action :authenticate_employee!
   def index
-    render :index, locals: { orders: Order.where(employee: current_employee) }
+    render :index, locals: { orders: Order.of_current_employee(current_employee).filtered_by_status(status),
+                             employee: current_employee }
   end
 
   def create
@@ -21,5 +22,9 @@ class OrdersController < ApplicationController
 
   def reward
     Reward.find(params[:reward])
+  end
+
+  def status
+    @status = params[:status]
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,6 +5,9 @@ class Order < ApplicationRecord
   belongs_to :reward
   belongs_to :employee
 
+  scope :filtered_by_status, ->(status) { where(status: status) if status.present? }
+  scope :of_current_employee, ->(employee) { where(employee: employee) }
+
   def purchase_price
     reward_snapshot.price
   end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,10 +1,16 @@
-<h1>Orders</h1>
-<% if orders.empty? %>
-<p>You have not placed any orders yet</p>
+<h1 class="text-center mb-3">Orders</h1>
+<% if orders.empty? && !params[:status]%>
+  <p  class="text-center" >You have not placed any orders yet</p>
+<% else  %>
+  <div class="d-flex justify-content-center w-100 mb-4 gap-3">
+    <%= link_to 'All orders', orders_path, class: 'btn btn-outline-dark' %>
+    <%= link_to 'Delivered', orders_path(status: 1), class: 'btn btn-outline-dark' %>
+    <%= link_to 'Not delivered', orders_path(employee, status: 0), class: 'btn btn-outline-dark' %>
+  </div>
 <% end %>
 <ul>
   <% orders.each do |order| %>
-    <li class="card" test_id="order_<%= order.id %>">
+    <li class="card mb-2" test_id="order_<%= order.id %>">
       <div class="card-header">
         Transaction date: <%= order.created_at.strftime('%d-%m-%Y') %>
       </div>

--- a/spec/system/listing_orders_spec.rb
+++ b/spec/system/listing_orders_spec.rb
@@ -1,54 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe 'Listing orders management', type: :system do
-  let(:employee) { create(:employee) }
   let(:admin_user) { create(:admin_user) }
-  let!(:kudo) { create(:kudo, receiver: employee) }
-  let(:reward) { create(:reward) }
-  let!(:order) { create(:order, employee: employee, reward: reward) }
+  let!(:order) { create(:order) }
 
   before do
-    login_employee(employee)
+    login_employee(order.employee)
     visit orders_path
   end
 
-  it 'shows employee\'s orders list' do
-    within("li[test_id='order_#{order.id}") do
-      expect(page).to have_text(order.reward_snapshot.title)
-      expect(page).to have_text(order.reward_snapshot.price)
-      expect(page).to have_text(order.reward_snapshot.description)
-      expect(page).to have_text(order.created_at.strftime('%d-%m-%Y'))
+  context 'when listing orders' do
+    let(:order_delivered) { create(:order, employee: order.employee, status: 1) }
+
+    it 'shows employee\'s orders list' do
+      visit orders_path
+      within("li[test_id='order_#{order.id}") do
+        expect(page).to have_text(order.reward_snapshot.title)
+        expect(page).to have_text(order.reward_snapshot.price)
+        expect(page).to have_text(order.reward_snapshot.description)
+        expect(page).to have_text(order.created_at.strftime('%d-%m-%Y'))
+      end
+    end
+
+    it 'enables filtering orders' do
+      expect(page).to have_link('All orders')
+      expect(page).to have_link('Delivered')
+      expect(page).to have_link('Not delivered')
+      order_delivered
+
+      click_on 'Delivered'
+      expect(page).to have_css("li[test_id='order_#{order_delivered.id}")
+      expect(page).not_to have_css("li[test_id='order_#{order.id}")
+
+      click_on 'Not delivered'
+      expect(page).not_to have_css("li[test_id='order_#{order_delivered.id}")
+      expect(page).to have_css("li[test_id='order_#{order.id}")
+
+      click_on 'All orders'
+      expect(page).to have_css("li[test_id='order_#{order_delivered.id}")
+      expect(page).to have_css("li[test_id='order_#{order.id}")
     end
   end
 
-  it 'does not change order\'s reward price when admin edits reward\'s current price' do
-    within('nav.navbar') do
-      expect(page).to have_content('Earned points: 0')
-    end
-    using_session('Admin') do
-      login_admin(admin_user)
+  context 'when editing order price' do
+    it 'does not change order\'s reward price when admin edits reward\'s current price' do
+      using_session('Admin') do
+        login_admin(admin_user)
 
-      visit('/admin/rewards')
+        visit('/admin/rewards')
 
-      click_on 'Edit'
-      fill_in('Price', with: 2.0)
-      click_button('Update Reward')
-      reward.reload
-    end
+        click_on 'Edit'
+        fill_in('Price', with: 2.0)
+        click_button('Update Reward')
+        order.reward.reload
+      end
 
-    refresh
+      refresh
 
-    click_on 'Rewards'
-    within("li[test_id='reward_#{reward.id}") do
-      expect(page).to have_text('Price: 2.0')
-    end
+      click_on 'Rewards'
+      within("li[test_id='reward_#{order.reward.id}") do
+        expect(page).to have_text('Price: 2.0')
+      end
 
-    click_on 'Orders'
-    within('nav.navbar') do
-      expect(page).to have_content('Earned points: 0')
-    end
-    within("li[test_id='order_#{order.id}") do
-      expect(page).to have_text('Reward price: 1.0')
+      click_on 'Orders'
+      within("li[test_id='order_#{order.id}") do
+        expect(page).to have_text('Reward price: 1.0')
+      end
     end
   end
 end


### PR DESCRIPTION
Sprint 5, task 2.
Implementations according to AC:

- An employee can click on the "delivered", "not delivered", and "all" links in the bought rewards list to filter their rewards
- Filtering rewards uses an URL query param key
- There's a single controller for displaying delivered, not delivered, and all bought rewards for employee
- There's a system spec for employee filtering their bought rewards

https://user-images.githubusercontent.com/56922072/178331324-3141cf8d-f507-4649-b2b7-e19b2167869b.mov


