### PR TITLE
Feature/add available kudos to all employees

### DIFF
--- a/app/controllers/adminUsers/employees_controller.rb
+++ b/app/controllers/adminUsers/employees_controller.rb
@@ -23,6 +23,27 @@ module AdminUsers
       redirect_to admin_users_employees_path, notice: 'Employee was successfully destroyed.'
     end
 
+    def add_kudos
+      render :add_kudos
+    end
+
+    def increase_number_of_available_kudos
+      number_of_kudos = params[:number_of_kudos].to_i
+      if number_of_kudos.between?(1, 20)
+        Employee.transaction do
+          Employee.all.each do |e|
+            e.increment(:number_of_available_kudos, number_of_kudos).save!
+          end
+          redirect_to admin_users_employees_path, notice: 'Numbers of available kudos where increased succesfully'
+        rescue StandardError => e
+          render :add_kudos, notice: "Update failed. Reason: #{e}"
+        end
+      else
+        render :add_kudos,
+               notice: 'Invalid input, please enter a number between 1 and 20'
+      end
+    end
+
     private
 
     def employee

--- a/app/views/admin_users/employees/add_kudos.erb
+++ b/app/views/admin_users/employees/add_kudos.erb
@@ -1,0 +1,15 @@
+<div class="d-sm-flex">
+  <div class="col-md-6">
+   <h2 class="text-center mb-5">Edit number of available kudos</h2>
+    <%= form_with url: increase_number_of_available_kudos_admin_users_employees_path, method: :patch do |form| %>
+      <div class="field">
+       <%= form.label :number_of_kudos %><br>
+      <%= form.number_field :number_of_kudos, min: 1, max: 20, step: 1, class: 'form-control' %>
+      </div>
+      <div class="actions">
+        <%= form.submit 'Add kudos', data: { confirm: 'Are you sure?' }, class: 'btn btn-primary mt-2 mb-2' %>
+      </div>
+      <%= link_to "Back", admin_users_employees_path, class: 'btn btn-light mb-5' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -29,6 +29,7 @@
                   <li><%= link_to "Employees", admin_users_employees_path, class: 'nav-link btn btn-link text-dark'  %></li>
                   <li><%= link_to "Company values", admin_users_company_values_path, class: 'nav-link btn btn-link text-dark'  %></li>
                   <li><%= link_to "Rewards", admin_users_rewards_path, class: 'nav-link btn btn-link text-dark'  %></li>
+                  <li class="d-flex justify-content-center me-1"><%= link_to 'Add kudos', add_kudos_admin_users_employees_path, class:' btn btn-warning' %></li>
                   <li class="d-flex justify-content-center"><%= link_to "Sign out", destroy_admin_user_session_path, method: :delete, class: 'btn btn-secondary text-white'  %></li>
                 <% end %>
               </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,12 @@ Rails.application.routes.draw do
       scope module: 'employees' do
         resources :orders, only: [:index, :update]
       end
+      collection do
+        get 'add_kudos'
+        patch 'increase_number_of_available_kudos'
+      end
     end
     resources :company_values
     resources :rewards
   end
-
 end

--- a/spec/system/admin/add_kudos_spec.rb
+++ b/spec/system/admin/add_kudos_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin adding kudos management', type: :system do
+  let(:admin_user) { create(:admin_user) }
+  let!(:employee1) { create(:employee, number_of_available_kudos: 2) }
+  let!(:employee2) { create(:employee, number_of_available_kudos: 3) }
+  let!(:employee3) { create(:employee, number_of_available_kudos: 4) }
+
+  before do
+    login_admin(admin_user)
+    visit('/admin/dashboard')
+  end
+
+  it 'enables increasing available kudos for all employees' do
+    click_link('Add kudos')
+    expect(page).to have_current_path(add_kudos_admin_users_employees_path)
+    expect(page).to have_text('Edit number of available kudos')
+
+    fill_in('Number of kudos', with: 5)
+    click_button('Add kudos')
+    page.accept_alert
+    expect(page).to have_current_path(admin_users_employees_path)
+    expect(page).to have_text('Numbers of available kudos where increased succesfully')
+    within("li[test_id='employee_#{employee1.id}") do
+      expect(page).to have_content('Number of kudos: 7')
+    end
+    within("li[test_id='employee_#{employee2.id}") do
+      expect(page).to have_content('Number of kudos: 8')
+    end
+    within("li[test_id='employee_#{employee3.id}") do
+      expect(page).to have_content('Number of kudos: 9')
+    end
+  end
+end


### PR DESCRIPTION
Feature implemented according to AC:

- There's an "Add Kudos" link in the admin panel's navigation which opens a form for adding kudos
- "Add Kudos" form has one numerical input for the number of kudos
- Submitting the "Add Kudos" form adds the same number of kudos to the `number_of_available_kudos` field of each employee
- After successfully submitting the "Add Kudos" form, admin sees a flash message with a confirmation
- There's a system spec for admin adding kudos to multiple employees


https://user-images.githubusercontent.com/56922072/181645112-d39e7b6a-94f5-4ce8-9ba4-fa259f8a5b8f.mov


