### PR TITLE
Feature/limit time for kudo edit and remove

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem 'pundit', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-mini-profiler (2.3.4)
@@ -307,6 +309,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-rails
   puma (~> 5.0)
+  pundit (~> 2.2)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   rspec-rails (~> 5.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
+  rescue_from Pundit::NotAuthorizedError, with: :employee_not_authorized
+
+  private
+
+  def employee_not_authorized
+    redirect_to kudos_path, alert: 'You cannot edit/remove this kudo'
+  end
+
+  def pundit_user
+    current_employee
+  end
 end

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -1,7 +1,7 @@
 class KudosController < ApplicationController
   before_action :authenticate_employee!
   def index
-    render :index, locals: { kudos: Kudo.includes(:receiver, :giver, :company_value) }
+    render :index, locals: { kudos: Kudo.includes(:receiver, :giver, :company_value).order(created_at: :desc) }
   end
 
   def show
@@ -29,6 +29,8 @@ class KudosController < ApplicationController
   end
 
   def update
+    authorize kudo
+
     if kudo.update(kudo_params)
       redirect_to kudo, notice: 'Kudo was successfully updated.'
     else
@@ -37,7 +39,8 @@ class KudosController < ApplicationController
   end
 
   def destroy
-    require_same_giver
+    authorize kudo
+
     kudo.destroy
     increase_giver_available_kudos
     redirect_to kudos_path, notice: 'Kudo was successfully destroyed.'
@@ -51,13 +54,6 @@ class KudosController < ApplicationController
 
   def kudo_params
     params.require(:kudo).permit(:id, :title, :content, :receiver_id, :giver_id, :company_value_id)
-  end
-
-  def require_same_giver
-    return unless current_employee != kudo.giver
-
-    flash[:alert] = 'You can only edit and delete your own kudos'
-    redirect_to kudos_path
   end
 
   def decrease_giver_available_kudos

--- a/app/helpers/kudos_links_helper.rb
+++ b/app/helpers/kudos_links_helper.rb
@@ -1,0 +1,5 @@
+module KudosLinksHelper
+  def disabled?(kudo)
+    policy(kudo).update? ? '' : 'disabled'
+  end
+end

--- a/app/helpers/kudos_links_helper.rb
+++ b/app/helpers/kudos_links_helper.rb
@@ -1,5 +1,0 @@
-module KudosLinksHelper
-  def disabled?(kudo)
-    policy(kudo).update? ? '' : 'disabled'
-  end
-end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,50 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+  attr_accessor :error_message
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/kudo_policy.rb
+++ b/app/policies/kudo_policy.rb
@@ -1,0 +1,21 @@
+class KudoPolicy < ApplicationPolicy
+  attr_accessor :error_message
+
+  def update?
+    true if not_too_late? && same_kudo_giver?
+  end
+
+  def destroy?
+    update?
+  end
+
+  private
+
+  def not_too_late?
+    record.created_at >= 5.minutes.ago
+  end
+
+  def same_kudo_giver?
+    user.id == record.giver_id
+  end
+end

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -11,8 +11,8 @@
         <p class="card-text"><span class="font-weight-bold">Company Value: </span><%= kudo.company_value.title %></p>
         <p class="card-text"><span class="font-weight-bold">Receiver: </span><%= kudo.receiver.email %></p>
         <p class="card-text"><span class="font-weight-bold">Giver: </span><%= kudo.giver.email %></p>
-        <%= link_to 'Edit', edit_kudo_path(kudo), class: "btn btn-warning me-1 #{disabled?(kudo)}"%> |
-        <%= link_to 'Destroy', kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger ms-1 #{disabled?(kudo)}" %>
+        <%= link_to 'Edit', edit_kudo_path(kudo), class: class_names("btn", "btn-warning", "ms-1", { disabled: !policy(kudo).update? })%> |
+        <%= link_to 'Destroy', kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: class_names("btn", "btn-danger", "ms-1", { disabled: !policy(kudo).destroy? }) %>
       </div>
     </li>
   <% end %>

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -11,10 +11,8 @@
         <p class="card-text"><span class="font-weight-bold">Company Value: </span><%= kudo.company_value.title %></p>
         <p class="card-text"><span class="font-weight-bold">Receiver: </span><%= kudo.receiver.email %></p>
         <p class="card-text"><span class="font-weight-bold">Giver: </span><%= kudo.giver.email %></p>
-        <% if kudo.giver == current_employee %>
-          <%= link_to 'Edit', edit_kudo_path(kudo), class: 'btn btn-warning' %> |
-          <%= link_to 'Destroy', kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %> 
-        <% end %>
+        <%= link_to 'Edit', edit_kudo_path(kudo), class: "btn btn-warning me-1 #{disabled?(kudo)}"%> |
+        <%= link_to 'Destroy', kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger ms-1 #{disabled?(kudo)}" %>
       </div>
     </li>
   <% end %>

--- a/spec/policies/kudo_policy_spec.rb
+++ b/spec/policies/kudo_policy_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe KudoPolicy do
+  subject(:kudo_policy) { described_class }
+
+  let!(:employee) { create(:employee) }
+  let!(:kudo) { create(:kudo, giver: employee) }
+
+  permissions :update?, :edit? do
+    it 'grants access if kudo was created less than 5 minutes ago' do
+      expect(kudo_policy).to permit(employee, kudo)
+    end
+
+    it 'denies access if kudo was created later than 5 minutes ago' do
+      travel 6.minutes
+      expect(kudo_policy).not_to permit(employee, kudo)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require './spec/support/factory_bot.rb'
 require 'capybara/rails'
+require "pundit/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end

--- a/spec/system/kudo_spec.rb
+++ b/spec/system/kudo_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Kudo management', type: :system do
     end
 
     it 'enables to edit the kudo' do
+      expect(page).not_to have_link('Edit', class: 'disabled')
       click_link('Edit')
       fill_in('Title', with: 'Edited title')
       click_button('Update Kudo')
@@ -71,12 +72,24 @@ RSpec.describe 'Kudo management', type: :system do
     end
 
     it 'enables to destroy the kudo' do
-      visit('/kudos')
+      expect(page).not_to have_link('Destroy', class: 'disabled')
       click_link('Destroy')
       page.accept_alert
       expect(page).to have_current_path(kudos_path)
       expect(page).to have_text('Kudo was successfully destroyed')
       expect(Kudo.count).to eq 0
+    end
+
+    it 'prevents from removing kudo created more than 5 minutes ago' do
+      travel 6.minutes
+      page.refresh
+      expect(page).to have_link('Destroy', class: 'disabled')
+    end
+
+    it 'prevents from editing kudo created more than 5 minutes ago' do
+      travel 6.minutes
+      visit('/kudos')
+      expect(page).to have_link('Edit', class: 'disabled')
     end
   end
 
@@ -89,13 +102,13 @@ RSpec.describe 'Kudo management', type: :system do
 
     it 'prevents from editing' do
       within("li#kudo_#{kudo.id}") do
-        expect(page).to have_no_link('Edit')
+        expect(page).to have_link('Edit', class: 'disabled')
       end
     end
 
     it 'prevents from destoying' do
       within("li#kudo_#{kudo.id}") do
-        expect(page).to have_no_link('Destroy')
+        expect(page).to have_link('Destroy', class: 'disabled')
       end
     end
   end


### PR DESCRIPTION
Implementation according to the AC:

- A kudo can only be edited or deleted for 5 minutes after it was sent
- If someone tries to edit or delete their kudo more than 5 minutes after it was sent, they see a flash message with an error
- If someone opens a page with a kudo more than 5 minutes after it was sent, the edit and delete links are disabled
- There's a policy for the kudo
- Policies use the "pundit" gem
- There's a unit spec for the kudo policy
- There's a system spec for not being able to remove a kudo 5 minutes after it was sent

https://user-images.githubusercontent.com/56922072/182605239-77a84405-2740-4877-80c1-53f0ccddf95a.mov


