### PR TITLE
Feat/import rewards from csv

### DIFF
--- a/app/controllers/adminUsers/rewards_controller.rb
+++ b/app/controllers/adminUsers/rewards_controller.rb
@@ -1,3 +1,4 @@
+require 'csv'
 module AdminUsers
   class RewardsController < AdminUsers::ApplicationController
     def index
@@ -41,6 +42,22 @@ module AdminUsers
       end
 
       redirect_to admin_users_rewards_path, notice: 'Reward was successfully destroyed.'
+    end
+
+    def upload_csv
+      render :upload_csv
+    end
+
+    def import_rewards
+      rewards_importer = RewardsImporter.new(params[:file])
+
+      unless rewards_importer.import
+        redirect_back fallback_location: upload_csv_admin_users_rewards_path,
+                      alert: rewards_importer.errors.join(' / ')
+        return
+      end
+
+      redirect_to admin_users_rewards_path, notice: 'Rewards imported successfully'
     end
 
     private

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -4,6 +4,7 @@ class Reward < ApplicationRecord
   has_one_attached :photo
 
   validates :title, :description, :price, presence: true
+  validates :title, uniqueness: true
   validates :price, numericality: { greater_than_or_equal_to: 1 }
   validate :correct_photo_type
 

--- a/app/services/rewards_importer.rb
+++ b/app/services/rewards_importer.rb
@@ -1,0 +1,61 @@
+class RewardsImporter
+  attr_reader :errors
+
+  def initialize(file)
+    @file = file
+    @errors = []
+  end
+
+  def import
+    return false unless file_present? && valid_format? && valid_category? && titles_unique?
+
+    Reward.transaction do
+      CSV.foreach(@file.path, headers: true) do |row|
+        reward_hash = row.to_hash
+        reward = Reward.find_or_initialize_by(title: reward_hash['Title'])
+        reward.description = reward_hash['Description']
+        reward.price = reward_hash['Price'].to_f
+        reward.category = Category.find_by(title: reward_hash['Category'])
+        reward.save!
+      end
+    rescue CSV::MalformedCSVError, ActiveRecord::RecordInvalid => e
+      @errors.push("Import failed, #{e.class}, message is #{e.message}")
+      false
+    end
+    true
+  end
+
+  private
+
+  def file_present?
+    return true if @file.present?
+
+    @errors.push('No file has been uploaded')
+    false
+  end
+
+  def valid_format?
+    return true if File.extname(@file) == '.csv'
+
+    @errors.push('Invalid file format')
+    false
+  end
+
+  def valid_category?
+    CSV.read(@file.path, headers: true)['Category'].each do |cat|
+      unless Category.find_by(title: cat)
+        @errors.push("Category  '#{cat}' does not exist")
+        false
+      end
+    end
+  end
+
+  def titles_unique?
+    titles = CSV.read(@file.path, headers: true)['Title']
+    duplicates = titles.select { |title| titles.count(title) > 1 }
+    return true if duplicates.empty?
+
+    @errors.push("Duplicated titles detected: #{duplicates.join(',')}")
+    false
+  end
+end

--- a/app/views/admin_users/rewards/index.html.erb
+++ b/app/views/admin_users/rewards/index.html.erb
@@ -24,3 +24,4 @@
   <% end %>
 </ul>
 <%= link_to 'New Reward', new_admin_users_reward_path(rewards), class: 'btn btn-primary mb-5 mt-3' %>
+<%= link_to 'Import Rewards', upload_csv_admin_users_rewards_path, class:' btn btn-warning mb-5 mt-3' %>

--- a/app/views/admin_users/rewards/upload_csv.erb
+++ b/app/views/admin_users/rewards/upload_csv.erb
@@ -1,0 +1,15 @@
+<div class="d-sm-flex">
+  <div class="col-md-6">
+   <h2 class="text-center mb-5">Import rewards</h2>
+    <%= form_with url: import_rewards_admin_users_rewards_path, method: :post do |form| %>
+      <div class="field">
+        <%= form.label :file %><br>
+        <%= form.file_field :file, class: 'form-control-file', required: true, accept: 'csv' %>
+      </div>
+      <div class="actions">
+        <%= form.submit 'Import rewards', class: 'btn btn-primary mt-2 mb-2' %>
+      </div>
+      <%= link_to "Back", admin_users_rewards_path, class: 'btn btn-light mb-5' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,12 @@ Rails.application.routes.draw do
       end
     end
     resources :company_values
-    resources :rewards
+    resources :rewards do
+      collection do
+        get 'upload_csv'
+        post 'import_rewards'
+      end
+    end
     resources :categories, except: [:show]
     get 'orders/export', to: 'orders#export'
   end

--- a/db/migrate/20220913094033_add_index_to_rewards_title.rb
+++ b/db/migrate/20220913094033_add_index_to_rewards_title.rb
@@ -1,0 +1,5 @@
+class AddIndexToRewardsTitle < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rewards, :title, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_17_070603) do
+ActiveRecord::Schema.define(version: 2022_09_13_094033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_070603) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "category_id"
     t.index ["category_id"], name: "index_rewards_on_category_id"
+    t.index ["title"], name: "index_rewards_on_title", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/fixtures/cat_err.csv
+++ b/spec/fixtures/cat_err.csv
@@ -1,0 +1,3 @@
+"Title","Description","Price","Category"
+"Title 1","Description","1","Category 1"
+"Title 2","Rewards desciption","2","Category 4"

--- a/spec/fixtures/no_error.csv
+++ b/spec/fixtures/no_error.csv
@@ -1,0 +1,3 @@
+"Title","Description","Price","Category"
+"First reward","New Description","2","Category 1"
+"New reward","Description","1","Category 1"

--- a/spec/fixtures/sample.pdf
+++ b/spec/fixtures/sample.pdf
@@ -1,0 +1,198 @@
+%PDF-1.3
+%‚„œ”
+
+1 0 obj
+<<
+/Type /Catalog
+/Outlines 2 0 R
+/Pages 3 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Pages
+/Count 2
+/Kids [ 4 0 R 6 0 R ] 
+>>
+endobj
+
+4 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 5 0 R
+>>
+endobj
+
+5 0 obj
+<< /Length 1074 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( A Simple PDF File ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( This is a small demonstration .pdf file - ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( just for use in the Virtual Mechanics tutorials. More text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 628.8480 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 616.8960 Td
+( text. And more text. Boring, zzzzz. And more text. And more text. And ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 604.9440 Td
+( more text. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 592.9920 Td
+( And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 569.0880 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 557.1360 Td
+( text. And more text. And more text. Even more. Continued on page 2 ...) Tj
+ET
+endstream
+endobj
+
+6 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 7 0 R
+>>
+endobj
+
+7 0 obj
+<< /Length 676 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( Simple PDF File 2 ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( ...continued from page 1. Yet more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 676.6560 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( text. Oh, how boring typing this stuff. But not as boring as watching ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( paint dry. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 640.8000 Td
+( Boring.  More, a little more text. The end, and just as well. ) Tj
+ET
+endstream
+endobj
+
+8 0 obj
+[/PDF /Text]
+endobj
+
+9 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/Name /F1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+
+10 0 obj
+<<
+/Creator (Rave \(http://www.nevrona.com/rave\))
+/Producer (Nevrona Designs)
+/CreationDate (D:20060301072826)
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000019 00000 n
+0000000093 00000 n
+0000000147 00000 n
+0000000222 00000 n
+0000000390 00000 n
+0000001522 00000 n
+0000001690 00000 n
+0000002423 00000 n
+0000002456 00000 n
+0000002574 00000 n
+
+trailer
+<<
+/Size 11
+/Root 1 0 R
+/Info 10 0 R
+>>
+
+startxref
+2714
+%%EOF

--- a/spec/fixtures/title-cat-err.csv
+++ b/spec/fixtures/title-cat-err.csv
@@ -1,0 +1,3 @@
+"Title","Description","Price","Category"
+"Title 1","Description","1","Category 1"
+"Title 1","Rewards desciption","2","Category 4"

--- a/spec/fixtures/title_err.csv
+++ b/spec/fixtures/title_err.csv
@@ -1,3 +1,3 @@
 "Title","Description","Price","Category"
 "Title 1","Description","1","Category 1"
-"Title 1","Rewards desciption","2","Category 4"
+"Title 1","Rewards desciption","2","Category 1"

--- a/spec/system/admin/import_rewards_from_csv_spec.rb
+++ b/spec/system/admin/import_rewards_from_csv_spec.rb
@@ -25,13 +25,25 @@ RSpec.describe 'Import rewards from csv', type: :system do
       end
     end
 
-    it 'aborts import when titles are not unique or category does not exist' do
+    it 'aborts import when titles are not unique' do
       click_link 'Import Rewards'
-      attach_file(File.absolute_path('./spec/fixtures/title-cat-err.csv'))
+      attach_file(File.absolute_path('./spec/fixtures/title_err.csv'))
       click_button 'Import rewards'
       within('div.alert') do
         expect(page).to have_content(
-          "Category 'Category 4' does not exist / Duplicated titles detected: Title 1,Title 1"
+          'Duplicated titles detected: Title 1,Title 1'
+        )
+      end
+      expect(page).not_to have_content('Title: New Reward')
+    end
+
+    it 'aborts import when category does not exist' do
+      click_link 'Import Rewards'
+      attach_file(File.absolute_path('./spec/fixtures/cat_err.csv'))
+      click_button 'Import rewards'
+      within('div.alert') do
+        expect(page).to have_content(
+          "Category 'Category 4' does not exist"
         )
       end
       expect(page).not_to have_content('Title: New Reward')

--- a/spec/system/admin/import_rewards_from_csv_spec.rb
+++ b/spec/system/admin/import_rewards_from_csv_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'Import rewards from csv', type: :system do
+  let(:admin_user) { create(:admin_user) }
+  let(:category) { create(:category, title: 'Category 1') }
+  let!(:reward) { create(:reward, title: 'First reward', price: 1.0, category: category) }
+
+  before do
+    login_admin(admin_user)
+    visit('/admin/rewards')
+  end
+
+  context 'when importing rewards from CSV' do
+    it 'updates rewards and import new form uploaded file' do
+      click_link 'Import Rewards'
+      attach_file(File.absolute_path('./spec/fixtures/no_error.csv'))
+      click_button 'Import rewards'
+      within('div.alert') do
+        expect(page).to have_content('Rewards imported successfully')
+      end
+      expect(page).to have_content('Title: New reward')
+      within("[test_id='reward_#{reward.id}']") do
+        expect(page).to have_content('Price: 2.0')
+        expect(page).to have_content('Description: New Description')
+      end
+    end
+
+    it 'aborts import when titles are not unique or category does not exist' do
+      click_link 'Import Rewards'
+      attach_file(File.absolute_path('./spec/fixtures/title-cat-err.csv'))
+      click_button 'Import rewards'
+      within('div.alert') do
+        expect(page).to have_content(
+          "Category 'Category 4' does not exist / Duplicated titles detected: Title 1,Title 1"
+        )
+      end
+      expect(page).not_to have_content('Title: New Reward')
+    end
+
+    it 'aborts import when file format is not .csv' do
+      click_link 'Import Rewards'
+      attach_file(File.absolute_path('./spec/fixtures/sample.pdf'))
+      click_button 'Import rewards'
+      within('div.alert') do
+        expect(page).to have_content('Invalid file format')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sprint 7, task 3 - Admin can import rewards from a CSV. According to the AC:

- On a dedicated view there is a form that allows the admin to upload a CSV with the reward title, description, price and category
- Reward's title should be unique
- When a reward exists its description, price and category should be update
- When an error happens an admin should see why import failed
- There is a system spec testing uploading a file

https://user-images.githubusercontent.com/56922072/191345380-040f7444-1845-47aa-91d8-da48349748ea.mp4

